### PR TITLE
shell_out: add whitespace after initial build cmd

### DIFF
--- a/src/doctest.zig
+++ b/src/doctest.zig
@@ -130,7 +130,7 @@ fn printOutput(
                 try build_args.appendSlice(&.{ "--zig-lib-dir", zig_lib_dir });
             }
 
-            try shell_out.print("$ zig build", .{});
+            try shell_out.print("$ zig build ", .{});
 
             switch (code.mode) {
                 .Debug => {},


### PR DESCRIPTION
Adding a whitespace to fix the commands displayed in the shell output of the [build system documentation](https://ziglang.org/learn/build-system/).

#### Examples of the missing whitespace:
![image](https://github.com/user-attachments/assets/99c339a5-0b71-4211-97ab-47d82bd1dd97)
![image](https://github.com/user-attachments/assets/8865e30e-3079-4698-94e3-e3bafb022aa4)
