### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.zig text eol=lf


### PR DESCRIPTION
git has very bad defaults when it comes to this so this should eliminate line ending errors when cloning zig code from this repo over the internet