### PR TITLE
Add missing space for build examples

### DIFF
--- a/src/doctest.zig
+++ b/src/doctest.zig
@@ -130,7 +130,7 @@ fn printOutput(
                 try build_args.appendSlice(&.{ "--zig-lib-dir", zig_lib_dir });
             }
 
-            try shell_out.print("$ zig build", .{});
+            try shell_out.print("$ zig build ", .{});
 
             switch (code.mode) {
                 .Debug => {},


### PR DESCRIPTION
Fixes https://github.com/ziglang/www.ziglang.org/issues/422