### PR TITLE
Prefix space in `additional_options` instead of suffix

### DIFF
--- a/src/doctest.zig
+++ b/src/doctest.zig
@@ -244,7 +244,7 @@ fn printOutput(
             }
             for (code.additional_options) |option| {
                 try build_args.append(option);
-                try shell_out.print("{s} ", .{option});
+                try shell_out.print(" {s}", .{option});
             }
 
             try shell_out.print("\n", .{});


### PR DESCRIPTION
Every shell commands in this page is wrong for very long time.

https://ziglang.org/learn/build-system/

The command should be `zig build run` instead of
<img width="400"  src="https://github.com/user-attachments/assets/07cc1713-589c-42fb-8a40-2bafae1075f1" />.

---

After this change:

<img width="340" src="https://github.com/user-attachments/assets/6843e54c-2304-4e10-8d1a-cda85d150564" />

---

The one in `ziglang/zig` also has this problem btw

https://github.com/ziglang/zig/blob/43e52ec5c5a2267791cb2aaaf37f3f84dbe29d25/tools/doctest.zig#L162
